### PR TITLE
Update about.css

### DIFF
--- a/css.files/about.css
+++ b/css.files/about.css
@@ -482,6 +482,11 @@ p{
     }
 }
 @media screen and  (max-width:430px){
+	
+      #close{
+        right: -85%;
+        width: 15%;
+    }
 
     p.card-text,
     p.card-text1{


### PR DESCRIPTION
on chrome mobile devices simulator close modal button seems centered and positioned nice,but on real devices is not positioned and centered.